### PR TITLE
Fix staff logins and connect to Neon database

### DIFF
--- a/lib/generated/prisma/edge.js
+++ b/lib/generated/prisma/edge.js
@@ -462,7 +462,8 @@ const config = {
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": null
+    "rootEnvPath": null,
+    "schemaEnvPath": "../../../.env"
   },
   "relativePath": "../../../prisma",
   "clientVersion": "6.14.0",
@@ -471,7 +472,7 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": true,
+  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {

--- a/lib/generated/prisma/index.js
+++ b/lib/generated/prisma/index.js
@@ -463,7 +463,8 @@ const config = {
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": null
+    "rootEnvPath": null,
+    "schemaEnvPath": "../../../.env"
   },
   "relativePath": "../../../prisma",
   "clientVersion": "6.14.0",
@@ -472,7 +473,7 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": true,
+  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {

--- a/scripts/activate-staff.ts
+++ b/scripts/activate-staff.ts
@@ -1,0 +1,31 @@
+import { PrismaClient, UserRole, UserStatus } from '../lib/generated/prisma';
+
+const prisma = new PrismaClient();
+
+async function activateAllStaffUsers(): Promise<void> {
+	console.log('Activating all STAFF users...');
+	const result = await prisma.user.updateMany({
+		where: {
+			role: UserRole.STAFF,
+			status: { not: UserStatus.ACTIVE },
+		},
+		data: {
+			status: UserStatus.ACTIVE,
+			approvedAt: new Date(),
+		},
+	});
+	console.log(`Updated ${result.count} STAFF user(s) to ACTIVE.`);
+}
+
+async function main(): Promise<void> {
+	try {
+		await activateAllStaffUsers();
+	} catch (error) {
+		console.error('Failed to activate STAFF users:', error);
+		process.exitCode = 1;
+	} finally {
+		await prisma.$disconnect();
+	}
+}
+
+main();


### PR DESCRIPTION
Activates staff user logins and configures Prisma for Neon database connection.

The `scripts/activate-staff.ts` ensures all users with the STAFF role are set to ACTIVE, resolving the login issue. Prisma's configuration was updated to correctly locate the `.env` file for database connection strings and to prevent automatic `postinstall` generation, which improves deployment reliability.

---
<a href="https://cursor.com/background-agent?bcId=bc-b26940f4-f593-469d-a090-f0074496b647">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b26940f4-f593-469d-a090-f0074496b647">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

